### PR TITLE
get rid of uneccesary dropdown to show role history, shows when clicked-on profile modal appears instead

### DIFF
--- a/components/team-section.tsx
+++ b/components/team-section.tsx
@@ -501,22 +501,6 @@ function TeamMemberCard({
                   {member.role}
                 </p>
               </div>
-              {hasRoleHistory && (
-                <button
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    setShowRoleHistory(!showRoleHistory);
-                  }}
-                  className="text-xs text-primary flex items-center ml-2 hover:underline"
-                >
-                  <ChevronDown
-                    className={cn(
-                      "h-3 w-3 transition-transform",
-                      showRoleHistory ? "rotate-180" : "",
-                    )}
-                  />
-                </button>
-              )}
             </div>
             {renderYearBadges()}
             {renderRoleHistory()}


### PR DESCRIPTION
We dont need a dropdown for showing role history, this simplifies the view so users can just click on the profile cards instead to see ALL information including role history.

closes #28 

OLD: (See green chevron arrow)
<img width="1256" height="528" alt="Screenshot 2026-06-16 at 6 22 26 PM" src="https://github.com/user-attachments/assets/06f6f59b-34f4-4a1c-bcab-fa1ab2fb3d94" />

NEW: (No green chevron arrow)
<img width="836" height="404" alt="Screenshot 2026-06-16 at 6 22 19 PM" src="https://github.com/user-attachments/assets/8fd97aab-176b-487e-ae93-c32723fb1171" />
