### PR TITLE
navbar cleanup, got rid of old contact section that was commented out, second "Home" section

### DIFF
--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -97,11 +97,9 @@ export function Navbar({ activeSection }: NavbarProps) {
   }, [])
 
   const navLinks = [
-    { name: "Home", href: "/#home", section: "home" },
     { name: "About", href: "/#about", section: "about" },
     { name: "Programs", href: "/#programs", section: "programs" },
     { name: "Team", href: "/#team", section: "team" },
-    // { name: "Contact", href: "/#contact", section: "contact" },
   ]
 
   // Animation variants


### PR DESCRIPTION
closes #27 
OLD: Both Home and FirstByte logo appear in navbar to redirect you to home hero section which is unneccessary
<img width="1215" height="84" alt="Screenshot 2026-06-17 at 12 07 08 PM" src="https://github.com/user-attachments/assets/bfde3cff-e5ff-45ec-a877-b5a7d6c99a0c" />
<img width="1256" height="783" alt="Screenshot 2026-06-17 at 12 07 22 PM" src="https://github.com/user-attachments/assets/9c7db6b4-2d07-4c58-a764-b55463071534" />

NEW: No Home in navbar, logo instead redirects you to home hero section
<img width="1254" height="99" alt="Screenshot 2026-06-17 at 12 06 05 PM" src="https://github.com/user-attachments/assets/92b524b7-3753-4f1a-b2ae-ec9a4f14cc69" />
<img width="1268" height="770" alt="Screenshot 2026-06-17 at 12 06 17 PM" src="https://github.com/user-attachments/assets/7756d629-c558-4e49-8621-98d4e69fb25d" />
